### PR TITLE
Crash fixes

### DIFF
--- a/PassFiltEx.c
+++ b/PassFiltEx.c
@@ -463,7 +463,7 @@ __declspec(dllexport) BOOL CALLBACK PasswordFilter(_In_ PUNICODE_STRING AccountN
 		PasswordCopy[Counter] = towlower(PasswordCopy[Counter]);
 	}	
 
-	while (CurrentNode->Next != NULL)
+	while (CurrentNode != NULL && CurrentNode->Next != NULL)
 	{
 		CurrentNode = CurrentNode->Next;
 

--- a/PassFiltEx.c
+++ b/PassFiltEx.c
@@ -471,7 +471,7 @@ __declspec(dllexport) BOOL CALLBACK PasswordFilter(_In_ PUNICODE_STRING AccountN
 
 		if (wcslen(CurrentNode->String) == 0)
 		{
-			EventWriteStringW2(L"[%s:%s@%d] ERROR: This blacklist token is 0 characters long. It will be skipped. Check your blacklist file for blank lines!", __FILENAMEW__, __FUNCTIONW__, __LINE__, CurrentNode->String);
+			EventWriteStringW2(L"[%s:%s@%d] ERROR: This blacklist token is 0 characters long. It will be skipped. Check your blacklist file for blank lines!", __FILENAMEW__, __FUNCTIONW__, __LINE__);
 
 			continue;
 		}

--- a/PassFiltEx.c
+++ b/PassFiltEx.c
@@ -458,10 +458,12 @@ __declspec(dllexport) BOOL CALLBACK PasswordFilter(_In_ PUNICODE_STRING AccountN
 
 	memcpy(PasswordCopy, Password->Buffer, Password->Length);
 
-	for (unsigned int Counter = 0; Counter < wcslen(PasswordCopy) - 1; Counter++)
-	{
-		PasswordCopy[Counter] = towlower(PasswordCopy[Counter]);
-	}	
+	if (Password->Length > 0) {
+		for (unsigned int Counter = 0; Counter < wcslen(PasswordCopy) - 1; Counter++)
+		{
+			PasswordCopy[Counter] = towlower(PasswordCopy[Counter]);
+		}	
+	}
 
 	while (CurrentNode != NULL && CurrentNode->Next != NULL)
 	{


### PR DESCRIPTION
This fixes all but one of the crashes we found.

- Crash on empty password.
- Crash on password reset with empty dictionary.
- Potential crash or heap corruption (or at least, incorrect code) when tracing is enabled and a blacklist line has 0 characters.

Will create an issue for the other crash I wasn't able to isolate yet.