### PR TITLE
Print to command line if DEBUG preprocessor macro is specified.

### DIFF
--- a/PassFiltEx.c
+++ b/PassFiltEx.c
@@ -708,6 +708,10 @@ ULONG EventWriteStringW2(_In_ PCWSTR String, _In_ ...)
 	_vsnwprintf_s(FormattedString, sizeof(FormattedString) / sizeof(wchar_t), _TRUNCATE, String, ArgPointer);
 
 	va_end(ArgPointer);
+	
+#if DEBUG
+	wprintf(L"%ls\r\n", FormattedString);
+#endif
 
 	return(EventWriteString(gEtwRegHandle, 0, 0, FormattedString));
 }

--- a/PassFiltEx.vcxproj
+++ b/PassFiltEx.vcxproj
@@ -102,6 +102,7 @@
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <EnablePREfast>true</EnablePREfast>
+	  <PreprocessorDefinitions>DEBUG=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">


### PR DESCRIPTION
Allows for easy command line debugging with PassFiltExTest. It just prints everything that'd normally go to ETW to stdout (in addition). Not useful in production so the flag is disabled in the Release build.