### PR TITLE
Fix use-after-free in blacklist refresh

### DIFF
--- a/PassFiltEx.c
+++ b/PassFiltEx.c
@@ -573,10 +573,12 @@ DWORD WINAPI BlacklistThreadProc(_In_ LPVOID Args)
 
 			// Need to clear blacklist and free memory first.
 			BADSTRING* CurrentNode = gBlacklistHead;
+			BADSTRING* NextNode = CurrentNode->Next;
 
-			while (CurrentNode->Next != NULL)
+			while (NextNode != NULL)
 			{
-				CurrentNode = CurrentNode->Next;
+				CurrentNode = NextNode;
+				NextNode = CurrentNode->Next;
 
 				if (HeapFree(GetProcessHeap(), 0, CurrentNode) == 0)
 				{


### PR DESCRIPTION
Currently, the loop to clear the previous blacklist can run into a use-after-free error (as seen in issue #7). `CurrentNode->Next` is checked after `CurrentNode` is freed. This leads to an access violation exception, leading to a crash. Most often seen when freeing very large lists.

This PR fixes this by introducing a `NextNode` variable to store the value of `CurrentNode->Next` *before* `CurrentNode` is freed.